### PR TITLE
Add documentation for DD outlier classifications

### DIFF
--- a/docs/reference/outlier.md
+++ b/docs/reference/outlier.md
@@ -1,0 +1,166 @@
+# Distance-to-Default Outliers (>13)
+
+This document catalogs the bank-year combinations that produced distance-to-default (DD) scores above 13 in the accounting- and market-based datasets investigated earlier. Entries are grouped by the key conditions that drive these extreme results—namely zero-cost debt inputs, negligible recorded debt, and very low leverage (debt-to-equity ratio ≤ 5%).
+
+## Accounting DD Outliers
+
+### Zero-Cost Debt Inputs
+
+| Instrument | Years with `wacc_cost_of_debt = wacc_debt_weight = 0` |
+|---|---|
+| BANF | 2023 |
+| COFS | 2019, 2020 |
+| EBC | 2022, 2023 |
+| ESQ | 2021, 2022, 2023 |
+| FHB | 2022 |
+| FNLC | 2018, 2019, 2021, 2022, 2023 |
+| FNWB | 2018, 2019 |
+| HBCP | 2018 |
+| LCNB | 2018, 2019, 2021 |
+| LKFN | 2021 |
+| OPBK | 2022 |
+| PCB | 2019, 2021, 2022 |
+| PDLB | 2019, 2022 |
+| PFIS | 2019 |
+| PVBC | 2021 |
+| STEL | 2021, 2022 |
+| WNEB | 2019 |
+| WSBF | 2021 |
+
+### Recorded Debt ≤ 1
+
+| Instrument | Years |
+|---|---|
+| BFIN | 2019 |
+| BMRC | 2021 |
+| ESQ | 2018, 2019, 2020, 2021, 2022, 2023 |
+| FCBC | 2020 |
+| FHB | 2017 |
+| LOB | 2019 |
+| OPBK | 2022 |
+
+### Debt-to-Equity Ratio ≤ 0.05
+
+| Instrument | Years |
+|---|---|
+| AROW | 2021 |
+| AUBN | 2018, 2019, 2021, 2022 |
+| BANF | 2016, 2017, 2018, 2019, 2021, 2022, 2023 |
+| BCML | 2019 |
+| BFIN | 2019 |
+| BMRC | 2017, 2018, 2019, 2020, 2021 |
+| CATY | 2021 |
+| CBNK | 2021 |
+| CBU | 2016 |
+| CHMG | 2018, 2019, 2020, 2021, 2022 |
+| COFS | 2019, 2020 |
+| COLB | 2016, 2017, 2018, 2021 |
+| CWBC | 2018, 2019, 2020, 2021 |
+| CZNC | 2018 |
+| EBC | 2022, 2023 |
+| EBTC | 2018 |
+| ESQ | 2018, 2019, 2020, 2021, 2022, 2023 |
+| EWBC | 2017, 2018, 2021 |
+| FBNC | 2021 |
+| FCBC | 2019, 2020, 2021, 2022, 2023 |
+| FDBC | 2022 |
+| FHB | 2017, 2019, 2022 |
+| FMNB | 2021 |
+| FNLC | 2018, 2019, 2021, 2022, 2023 |
+| FNWB | 2018, 2019 |
+| FRBKQ | 2017, 2019 |
+| FSBW | 2019 |
+| GABC | 2019, 2022 |
+| HBCP | 2018, 2019, 2021 |
+| HFWA | 2018, 2019 |
+| INDB | 2022 |
+| LCNB | 2018, 2019, 2021, 2022 |
+| LKFN | 2019, 2021 |
+| LOB | 2017, 2018, 2019 |
+| NBHC | 2020, 2021 |
+| NRIM | 2019, 2021, 2022 |
+| OBK | 2019 |
+| OPBK | 2022 |
+| PCB | 2019, 2021, 2022 |
+| PDLB | 2019, 2022 |
+| PFIS | 2019 |
+| PVBC | 2021 |
+| RMBI | 2021, 2022 |
+| SFST | 2018 |
+| STEL | 2019, 2021, 2022 |
+| THFF | 2017 |
+| VBTX | 2017, 2018 |
+| WABC | 2016, 2017, 2018, 2019 |
+| WASH | 2021 |
+| WNEB | 2019 |
+| WSBF | 2021 |
+
+## Market DD Outliers
+
+### Zero-Cost Debt Inputs
+
+| Instrument | Years with `wacc_cost_of_debt = wacc_debt_weight = 0` |
+|---|---|
+| BANF | 2023 |
+| ESQ | 2021, 2022, 2023 |
+| FHB | 2022 |
+| HBCP | 2018 |
+| LCNB | 2019, 2021 |
+| LKFN | 2021 |
+| OPBK | 2022 |
+| PCB | 2019, 2021, 2022 |
+| PDLB | 2019 |
+| PVBC | 2021 |
+| STEL | 2021 |
+| WSBF | 2021 |
+
+### Recorded Debt ≤ 1
+
+| Instrument | Years |
+|---|---|
+| BFIN | 2019 |
+| BMRC | 2021 |
+| ESQ | 2018, 2019, 2020, 2021, 2022, 2023 |
+| FCBC | 2020 |
+| FHB | 2017 |
+| LOB | 2019 |
+| OPBK | 2022 |
+
+### Debt-to-Equity Ratio ≤ 0.05
+
+| Instrument | Years |
+|---|---|
+| AROW | 2021 |
+| AUBN | 2019, 2021, 2022 |
+| BANF | 2016, 2017, 2018, 2019, 2023 |
+| BCML | 2019 |
+| BFIN | 2019 |
+| BMRC | 2017, 2018, 2019, 2020, 2021 |
+| CATY | 2021 |
+| CHMG | 2018, 2019 |
+| COLB | 2016, 2017, 2018, 2021 |
+| CWBC | 2018, 2019 |
+| CZNC | 2018 |
+| ESQ | 2018, 2019, 2020, 2021, 2022, 2023 |
+| EWBC | 2017, 2021 |
+| FCBC | 2019, 2020, 2021, 2022, 2023 |
+| FHB | 2017, 2019, 2022 |
+| FRBKQ | 2017 |
+| HBCP | 2018, 2019 |
+| HFWA | 2019 |
+| INDB | 2022 |
+| LCNB | 2019, 2021 |
+| LKFN | 2021 |
+| LOB | 2017, 2018, 2019 |
+| NBHC | 2021 |
+| OPBK | 2022 |
+| PCB | 2019, 2021, 2022 |
+| PDLB | 2019 |
+| PVBC | 2021 |
+| RMBI | 2021 |
+| STEL | 2019, 2021 |
+| THFF | 2017 |
+| VBTX | 2017 |
+| WABC | 2017, 2018, 2019 |
+| WSBF | 2021 |
+


### PR DESCRIPTION
## Summary
- add `outlier.md` to document the distance-to-default observations above 13
- catalog accounting and market outliers by zero-cost debt inputs, minimal debt, and low leverage

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68decac5d3b0832e8c81d13ac99b2da9